### PR TITLE
codi再起動用のclooudbuildファイル

### DIFF
--- a/deployments/restart_cloudbuild.yaml
+++ b/deployments/restart_cloudbuild.yaml
@@ -1,0 +1,36 @@
+steps:
+- id: stop
+  name: gcr.io/cloud-builders/gcloud
+  args: [
+   'app',
+   'versions',
+   'stop',
+   'codimd-production-latest',
+   '--service',
+   'codimd-production',
+   '--project',
+   'smarthr-corporate',
+   '--quiet'
+  ]
+  timeout: 900s
+  waitFor:
+    - push
+- id: start
+  name: gcr.io/cloud-builders/gcloud
+  args: [
+   'app',
+   'versions',
+   'start',
+   'codimd-production-latest',
+   '--service',
+   'codimd-production',
+   '--project',
+   'smarthr-corporate',
+   '--quiet'
+  ]
+  timeout: 900s
+  waitFor:
+    - push
+options:
+  logging: CLOUD_LOGGING_ONLY
+timeout: 1200s


### PR DESCRIPTION
AppEngineで稼働しているcodimdですが、頻繁に再起動対応を手動で実施しています
これらを解消できるように、CloudBuild上で実行するようにしたいと思います。
そのための再起動のコマンド処理をまとめたCloudBuildファイルを用意しました