### PR TITLE
GMPでメトリクスが取得できるようにprometheusの設定一式を追加

### DIFF
--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,0 +1,3 @@
+FROM gke.gcr.io/prometheus-engine/prometheus:v2.35.0-gmp.2-gke.0
+
+COPY config.yaml /prometheus/config_out/config.yaml

--- a/prometheus/cloudbuild.yaml
+++ b/prometheus/cloudbuild.yaml
@@ -1,0 +1,40 @@
+steps:
+- id: build
+  name: gcr.io/cloud-builders/docker
+  args: [
+  'build',
+  '-f',
+  'prometheus/Dockerfile',
+  '-t',
+  'asia-northeast1-docker.pkg.dev/$PROJECT_ID/codimd-prometheus/codimd-prometheus:latest',
+  '.'
+  ]
+  timeout: 900s
+- id: push
+  name: gcr.io/cloud-builders/docker
+  args: [
+  'push',
+  'asia-northeast1-docker.pkg.dev/$PROJECT_ID/codimd-prometheus/codimd-prometheus:latest'
+  ]
+  timeout: 900s
+  waitFor:
+    - build
+- id: deploy
+  name: gcr.io/cloud-builders/gcloud
+  args: [
+  'run',
+  'deploy',
+  'codimd-prometheus',
+  '--image',
+  'asia-northeast1-docker.pkg.dev/$PROJECT_ID/codimd-prometheus/codimd-prometheus:latest',
+  '--region',
+  'asia-northeast1'
+  ]
+  timeout: 900s
+  waitFor:
+    - push
+options:
+  pool:
+    name: projects/$PROJECT_ID/locations/asia-northeast1/workerPools/private-pool
+  logging: CLOUD_LOGGING_ONLY
+timeout: 1200s

--- a/prometheus/config.yaml
+++ b/prometheus/config.yaml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    project_id: smarthr-corporate
+    location: asia-northeast1
+    namespace: codimd
+scrape_configs:
+  - job_name: codimd-router
+    honor_timestamps: true
+    scrape_interval: 5s
+    scrape_timeout: 5s
+    metrics_path: /metrics/router
+    scheme: https
+    static_configs:
+      - targets:
+          - codimd.kufu.tools
+  - job_name: codimd
+    honor_timestamps: true
+    scrape_interval: 5s
+    scrape_timeout: 5s
+    metrics_path: /metrics/codimd
+    scheme: https
+    static_configs:
+      - targets:
+          - codimd.kufu.tools


### PR DESCRIPTION
codimdによると以下のPRでprometheusを使えばメトリクス情報を拾えることが分かった
https://github.com/hackmdio/codimd/issues/1466

Google CloudにはManaged Prometheusがあるので、そちらでイメージが取得できるように対応したい