### PR TITLE
shirabeのmetrics設定の追加対応

### DIFF
--- a/prometheus/config.yaml
+++ b/prometheus/config.yaml
@@ -24,3 +24,12 @@ scrape_configs:
     static_configs:
       - targets:
           - codimd.kufu.tools
+  - job_name: shirabe-router
+    honor_timestamps: true
+    scrape_interval: 5s
+    scrape_timeout: 5s
+    metrics_path: /metrics/router
+    scheme: https
+    static_configs:
+      - targets:
+          - shirabe.kufu.tools


### PR DESCRIPTION
shirabeもnodeで動いているのでpromethusでメトリクスデータを拾えるように対応しておきます