### PR TITLE
 🔼  DB最大コネクション数の引き上げ

### DIFF
--- a/deployments/production/app.yaml
+++ b/deployments/production/app.yaml
@@ -44,3 +44,4 @@ env_variables:
   NODE_ENV: sm://smarthr-corporate/codimd_production_node_env
   PGSSLMODE: sm://smarthr-corporate/codimd_production_pgsslmode
   NODE_OPTIONS: --max-old-space-size=2000
+  DB_MAX_CONNECTION: 800

--- a/deployments/staging/app.yaml
+++ b/deployments/staging/app.yaml
@@ -44,3 +44,4 @@ env_variables:
   NODE_ENV: sm://smarthr-corporate/codimd_staging_node_env
   PGSSLMODE: sm://smarthr-corporate/codimd_staging_pgsslmode
   CMD_LOGLEVEL: sm://smarthr-corporate/codimd_staging_cmd_loglevel
+  DB_MAX_CONNECTION: 800

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -32,6 +32,10 @@ module.exports = {
   forbiddenNoteIDs: toArrayConfig(process.env.CMD_FORBIDDEN_NOTE_IDS),
   defaultPermission: process.env.CMD_DEFAULT_PERMISSION,
   dbURL: process.env.CMD_DB_URL,
+  db: {
+    pool: {
+      max: process.env.DB_MAX_CONNECTION },
+  },
   sessionSecret: process.env.CMD_SESSION_SECRET,
   sessionLife: toIntegerConfig(process.env.CMD_SESSION_LIFE),
   responseMaxLag: toIntegerConfig(process.env.CMD_RESPONSE_MAX_LAG),


### PR DESCRIPTION
現状デフォルト値の5で運用しているため、インフラ上限まで引き上げます 🔼 

- sequelize (connection pool) option
  - https://sequelize.org/api/v6/class/src/sequelize.js~sequelize#instance-constructor-constructor
- ここで使います
  - https://github.com/kufu/hackmd/blob/3e7544576b2d5d26efe8dfa40cdb9f1116ebaa78/lib/models/index.js#L21