### PR TITLE
🔧 実行に60〜90秒を要しているクエリのチューニング

### DIFF
--- a/lib/migrations/20230831234802-revision-add-index.js
+++ b/lib/migrations/20230831234802-revision-add-index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addIndex('Revisions', ['noteId'], {})
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('Revisions', 'noteId')
+  }
+};


### PR DESCRIPTION
## 背景

🎫 詳細はチケット https://smarthr.atlassian.net/browse/CPEN-1942

実行に60〜90secかかっているクエリがあって、深刻なパフォーマンス低下を引き起こしているのでチューニングします。
原因は、10^6〜10^7レコードが存在するRevisionテーブルをselectする際にシーケンシャルスキャンになっているため。
where条件的に、noteIdカラムにインデックスを追加すれば解消すると思います。
もし改善しなければ他のチューニング手段を考えます。

stagingでは動作確認して、凪の状態で20〜30秒かかっていたものが1秒未満で完了する状態にはなっています。

![image](https://github.com/kufu/hackmd/assets/38120991/67cd391a-1504-41cf-9c80-7f0b12838240)

