### PR TITLE
Revisions tableの取得件数を制限

### DIFF
--- a/hackmd/lib/migrations/20230831234802-revision-add-index.js
+++ b/hackmd/lib/migrations/20230831234802-revision-add-index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addIndex('Revisions', ['noteId'], {})
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('Revisions', 'noteId')
+  }
+};

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -138,7 +138,8 @@ module.exports = function (sequelize, DataTypes) {
       where: {
         noteId: note.id
       },
-      order: [['createdAt', 'DESC']]
+      order: [['createdAt', 'DESC']],
+      limit: 100
     }).then(function (revisions) {
       if (revisions.length <= 0) return callback(null, null)
       // measure target revision position
@@ -238,7 +239,8 @@ module.exports = function (sequelize, DataTypes) {
       where: {
         noteId: note.id
       },
-      order: [['createdAt', 'DESC']]
+      order: [['createdAt', 'DESC']],
+      limit: 100
     }).then(function (revisions) {
       if (revisions.length <= 0) {
         // if no revision available

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -150,7 +150,8 @@ module.exports = function (sequelize, DataTypes) {
             [Op.gte]: time
           }
         },
-        order: [['createdAt', 'DESC']]
+        order: [['createdAt', 'DESC']],
+        limit: 100
       }).then(function (count) {
         if (count <= 0) return callback(null, null)
         sendDmpWorker({

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -116,7 +116,8 @@ module.exports = function (sequelize, DataTypes) {
       where: {
         noteId: note.id
       },
-      order: [['createdAt', 'DESC']]
+      order: [['createdAt', 'DESC']],
+      limit: 100
     }).then(function (revisions) {
       var data = []
       for (var i = 0, l = revisions.length; i < l; i++) {


### PR DESCRIPTION
Revisions tableの取得件数を制限します。

ref: https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#limits-and-pagination