### PR TITLE
Decrease DB max connection for production

### DIFF
--- a/deployments/production/app.yaml
+++ b/deployments/production/app.yaml
@@ -44,4 +44,4 @@ env_variables:
   NODE_ENV: sm://smarthr-corporate/codimd_production_node_env
   PGSSLMODE: sm://smarthr-corporate/codimd_production_pgsslmode
   NODE_OPTIONS: --max-old-space-size=2000
-  DB_MAX_CONNECTION: 800
+  DB_MAX_CONNECTION: 700

--- a/deployments/staging/app.yaml
+++ b/deployments/staging/app.yaml
@@ -44,4 +44,4 @@ env_variables:
   NODE_ENV: sm://smarthr-corporate/codimd_staging_node_env
   PGSSLMODE: sm://smarthr-corporate/codimd_staging_pgsslmode
   CMD_LOGLEVEL: sm://smarthr-corporate/codimd_staging_cmd_loglevel
-  DB_MAX_CONNECTION: 800
+  DB_MAX_CONNECTION: 700


### PR DESCRIPTION
APからのコネクション数をインフラ上限値にしていると、AP以外からの接続込でインフラ上限を超えた場合にconnection failedになりかねないので、コネクション最大数を下げます。

https://cloudlogging.app.goo.gl/oJHYJug3Ks3DsTpB7