### PR TITLE
anchorと関連jsが動いてなかったので修正対応

### DIFF
--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -19,6 +19,9 @@
                                 <button class="btn btn-sm btn-success ui-signin" data-toggle="modal" data-target=".signin-modal"><%= __('Sign In') %></button>
                                 <% } %>
                             </div>
+                            <form name="exportNoteData" action="<%- serverURL %>/me/export" method="post">
+                                <input type="hidden" name="_csrf" value="<%- csrfToken %>">
+                            </form>
                             <div class="ui-signout" style="float: right; margin-top: 8px;<% if(!signin) { %> display: none;<% } %>">
                                 <a type="button" href="<%- serverURL %>/new" class="btn btn-sm btn-primary"><i class="fa fa-plus"></i> <%= __('New note') %></a>
                                 <span class="ui-profile dropdown pull-right">
@@ -27,14 +30,11 @@
                                     </button>
                                     <ul class="dropdown-menu" aria-labelledby="profileLabel">
                                         <li><a href="<%- serverURL %>/features"><i class="fa fa-dot-circle-o fa-fw"></i> <%= __('Features') %></a></li>
-                                        <li><a href="<%- serverURL %>/me/export"><i class="fa fa-cloud-download fa-fw"></i> <%= __('Export user data') %></a></li>
+                                        <li><a href="#" class="ui-export-user-data"><i class="fa fa-cloud-download fa-fw"></i> <%= __('Export user data') %></a></li>
                                         <li><a href="<%- serverURL %>/logout"><i class="fa fa-sign-out fa-fw"></i> <%= __('Sign Out') %></a></li>
                                     </ul>
                                 </span>
                             </div>
-                            <form name="exportNoteData" action="<%- serverURL %>/me/export" method="post">
-                                <input type="hidden" name="_csrf" value="<%- csrfToken %>">
-                            </form>
                         </ul>
                     </nav>
                 </div>


### PR DESCRIPTION
元の実装は、このようにjsでpostして動かすようになっているらしい

- https://github.com/hackmdio/codimd/blob/2.4.2/public/views/index/body.ejs#L22-L24
- https://github.com/hackmdio/codimd/blob/2.4.2/public/views/index/body.ejs#L33
- https://github.com/hackmdio/codimd/blob/2.4.2/public/js/cover.js#L432-L434

しかしながら、現状の実装だとリンクのままgetでアクセスするようになっているので、エラーになるようです
そのため、元の実装に追従してPOSTで動かすようにしました
変更元のこちらをみる限り、JS側は対応できているようなので画面の内容だけ修正しています
https://github.com/kufu/hackmd/commit/b8f32ca0da4beee86b260e02af1575bbc17a45df#diff-5b2f7bbe8fedd91a0c470a11e3e8dfdf75eceafa4be0f9c83b87324de2173562


とはいえ、これまで言われてこなかったのであんまり気にするような機能でもないらしい